### PR TITLE
Implements a more cURLesque api for 1.1

### DIFF
--- a/lib/bfg.ex
+++ b/lib/bfg.ex
@@ -3,6 +3,17 @@ defmodule Bfg do
   Documentation for Bfg.
   """
 
+  def get("http://" <> url) do
+    {domain, slug} = parse_url(url)
+    get(domain, 80, slug, [])
+  end
+
+
+  def get("https://" <> url) do
+    {domain, slug} = parse_url(url)
+    get(domain, 443, slug, [])
+  end
+
 
   def get(domain, port, slug) when is_binary(domain) do
     get(String.to_charlist(domain), port, slug)
@@ -133,5 +144,16 @@ defmodule Bfg do
     auth= Base.encode64("#{user}:#{password}")
     {"Authorization", "Basic " <> auth}
   end
+
+  defp parse_url(url) when is_binary(url) do
+    String.split(url, "/")
+    |> parse_url()
+  end
+
+  defp parse_url([domain | rest ]) do
+    [slug] = for item <- rest, do: item <> "/"
+    {String.to_charlist(domain), String.to_charlist(slug)}
+  end
+
 
 end

--- a/lib/bfg.ex
+++ b/lib/bfg.ex
@@ -14,6 +14,15 @@ defmodule Bfg do
     get(domain, 443, slug, [])
   end
 
+  def get("http://" <> url, auth) do
+    {domain, slug} = parse_url(url)
+    get(domain, 80, slug, [], auth)
+  end
+
+  def get("https://" <> url, auth) do
+    {domain, slug} = parse_url(url)
+    get(domain, 443, slug, [], auth)
+  end
 
   def get(domain, port, slug) when is_binary(domain) do
     get(String.to_charlist(domain), port, slug)

--- a/lib/bfg.ex
+++ b/lib/bfg.ex
@@ -8,7 +8,6 @@ defmodule Bfg do
     get(domain, 80, slug, [])
   end
 
-
   def get("https://" <> url) do
     {domain, slug} = parse_url(url)
     get(domain, 443, slug, [])
@@ -51,6 +50,26 @@ defmodule Bfg do
 
   end
 
+  def post("http://" <> url, body) do
+    {domain, slug} = parse_url(url)
+    post(domain, 80, slug, [], body)
+  end
+
+  def post("https://" <> url, body) do
+    {domain, slug} = parse_url(url)
+    post(domain, 443, slug, [], body)
+  end
+
+  def post("http://" <> url, body, auth) do
+    {domain, slug} = parse_url(url)
+    post(domain, 80, slug, [], body, auth)
+  end
+
+  def post("https://" <> url, body, auth) do
+    {domain, slug} = parse_url(url)
+    post(domain, 443, slug, [], body, auth)
+  end
+
   def post(domain, port, slug, headers, body, auth) do
     auth_header = basic_auth(auth)
     post(domain, port, slug, [auth_header | headers], body )
@@ -66,6 +85,27 @@ defmodule Bfg do
       {:response, :nofin, _status, headers} -> {:ok, body} = :gun.await_body(pid, ref)
     end
   end
+
+  def delete("http://" <> url) do
+    {domain, slug} = parse_url(url)
+    delete(domain, 80, slug, [])
+  end
+
+  def delete("https://" <> url) do
+    {domain, slug} = parse_url(url)
+    delete(domain, 443, slug, [])
+  end
+
+  def delete("http://" <> url, auth) do
+    {domain, slug} = parse_url(url)
+    delete(domain, 80, slug, [], auth)
+  end
+
+  def delete("https://" <> url, auth) do
+    {domain, slug} = parse_url(url)
+    delete(domain, 443, slug, [], auth)
+  end
+
 
   def delete(domain, port, slug, headers, auth) do
     auth_header = basic_auth(auth)

--- a/lib/bfg.ex
+++ b/lib/bfg.ex
@@ -149,7 +149,9 @@ defmodule Bfg do
     String.split(url, "/")
     |> parse_url()
   end
-
+  defp parse_url([domain | [] ]) do
+    {String.to_charlist(domain), '/'}
+  end
   defp parse_url([domain | rest ]) do
     [slug] = for item <- rest, do: item <> "/"
     {String.to_charlist(domain), String.to_charlist(slug)}


### PR DESCRIPTION
Rationale: In order to drive usage of gun instread of always
using the more correct model setting up http connections
that gun presents you with I am adding some syntax sugar
to make it a more cURLesque api for when we don't need
to worry about the big stuff.

Proof of concept commit